### PR TITLE
Add new attribute SAI_BUFFER_POOL_ATTR_RESERVED_BUFFER_SIZE

### DIFF
--- a/inc/saibuffer.h
+++ b/inc/saibuffer.h
@@ -410,6 +410,25 @@ typedef enum _sai_buffer_pool_attr_t
     SAI_BUFFER_POOL_ATTR_SELECTIVE_COUNTER_LIST,
 
     /**
+     * @brief Reserved buffer pool size in bytes that cannot be used
+     * by other pools in the cases where cumulative buffer pool sizes
+     * exceed SAI_SWITCH_ATTR_TOTAL_BUFFER_SIZE.
+     *
+     * If pool RESERVED_BUFFER_SIZE is 0, pool reserve is equal to the
+     * cumulative RESERVED_BUFFER_SIZE across all queues or ingress
+     * priority groups attached to this pool.
+     *
+     * Reserved pool size is included in the corresponding
+     * buffer pool size SAI_BUFFER_POOL_ATTR_SIZE.
+     * Therefore reserved_buffer_size <= (pool_size - shared_headroom_size)
+     *
+     * @type sai_uint64_t
+     * @flags CREATE_AND_SET
+     * @default 0
+     */
+    SAI_BUFFER_POOL_ATTR_RESERVED_BUFFER_SIZE,
+
+    /**
      * @brief End of attributes
      */
     SAI_BUFFER_POOL_ATTR_END,


### PR DESCRIPTION
SAI Buffer Pool Reserved Memory 

## Overview ##

SAI Buffer APIs currently support the concept of 'reserved buffer size' on a buffer profile with the attribute SAI_BUFFER_PROFILE_ATTR_RESERVED_BUFFER_SIZE.
SAI_BUFFER_POOL_ATTR_SHARED_SIZE is implicitly derived from the cumulative of profile reserve across all ingress priority groups as defined in the current spec. 

Currently there is no way to explicitly define 'reserved buffer size' on a buffer pool directly. 
Explicit configuration of this value allows for more optimized buffer allocation on multi-pool systems.

## Reserved Buffer Size Problem Example ##
On a system with a completely shared buffer, it can be more efficient to allocate pool sizes that overlap. Allocating pools in this way can cause issues with per-profile reserve however. 

Consider a system with 100 GB of available buffers and 3 user defined pools. The system has 10 ports and 4 lossy queues per port.

The desired buffer carving for this system is as follows:
1. Traffic is separated into 3 separate user pools, lossy, lossless, and control.
2. lossy traffic can consume up to 80MB
3. lossy traffic can consume up to 80MB
4. control traffic can consume up to 30MB
5. lossy queues have enough reserved buffer to maintain line rate (1MB per port for this example)
6. control queue 7 gets 1MB of reserved memory
7. 9 MB of memory is guaranteed among all of the 'control' queues.


In the current model, item 5 is configurable through the existing buffer profile attribute SAI_BUFFER_PROFILE_ATTR_RESERVED_BUFFER_SIZE by setting the value to to 1MB. 
Applied across all 'lossy' queues however, this results in needing to reserve 40MB of system memory for this pool. (10 Ports * 1 MB/Port * 4 Queues/Port). The amount of reserved buffer needed to maintain line rate is per-port, not per-queue however. This allocation ends up wasting a lot of memory. 

Likewise, the current model supports configuring item 6 with SAI_BUFFER_PROFILE_ATTR_RESERVED_BUFFER_SIZE.

The current model does not support configuring item 7.

Following list of changes are being proposed:

## New Attribute: SAI_BUFFER_POOL_ATTR_RESERVED_BUFFER_SIZE ##

SAI_BUFFER_POOL_ATTR_RESERVED_BUFFER_SIZE is the amount of buffer size in bytes that are guaranteed to the pool. This allows for oversubscription of system memory when creating pools while still providing guaranteed memory. This becomes significant for systems with fully shared buffer memory and a pool allocation model with 3 or more pools.

### Reserved Buffer Size Solution Example ###

This new attribute enables for optimization for the memory waste described in the lossy queue example above. 
Setting SAI_BUFFER_POOL_ATTR_RESERVED_BUFFER_SIZE = 10MB (1MB/port * 10 ports) 'guarantees' the lossy pool 10 MB the other pools cannot use, thereby protecting the line rate guarantee for lossy queues.

SAI_BUFFER_PROFILE_ATTR_RESERVED_BUFFER_SIZE=1MB will still be set on the lossy buffer profile to provide guarantee between queues within the pool.

This attribute also enables reserving 10MB total for control traffic, with 1MB of that 10MB specifically dedicated to queue 7.

This is achieved by setting SAI_BUFFER_POOL_ATTR_RESERVED_BUFFER_SIZE = 10MB for the control pool. 
2 buffer profiles would then be created on this pool, one with SAI_BUFFER_PROFILE_ATTR_RESERVED_BUFFER_SIZE=0MB (queues 0-6) and one with SAI_BUFFER_PROFILE_ATTR_RESERVED_BUFFER_SIZE=1MB (queue 7)

